### PR TITLE
Route via Handle

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -78,7 +78,8 @@ class EventsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_event
-    @event = Event.find(params[:id])
+    @event = Event.find_by("LOWER(handle) = ?", params[:id]&.downcase)
+    @event ||= Event.find(params[:id])
     authorize @event
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -70,7 +70,8 @@ class ProfilesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_profile
-    @profile = policy_scope(Profile).find(params[:id])
+    @profile = policy_scope(Profile).find_by("LOWER(handle) = ?", params[:id]&.downcase)
+    @profile ||= policy_scope(Profile).find(params[:id])
     authorize @profile
   end
 

--- a/app/models/concerns/handleable.rb
+++ b/app/models/concerns/handleable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Allows the object to be called by a handle in the URL
+# Modifications to the controller are also necessary.
+module Handleable
+  extend ActiveSupport::Concern
+
+  URL_POSSIBLE_REGEX = /\A[A-z0-9\-]+\z/
+
+  included do
+    validates :handle, presence: true,
+                       format: { with: URL_POSSIBLE_REGEX },
+                       uniqueness: { case_sensitive: false }
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,13 +2,12 @@
 
 # Events are events that you can attend.
 class Event < ApplicationRecord
+  include ::Handleable
+
   has_many :event_attendees, dependent: :delete_all
   has_many :attendees, through: :event_attendees, source: :profile
 
   validates :start_at, :end_at, presence: true
-  validates :handle, presence: true,
-                     format: { with: /\A[a-zA-Z0-9]+\z/, message: "Only letters and numbers are allowed" },
-                     uniqueness: { case_sensitive: true }
 
   scope :ongoing_or_upcoming, -> { where("end_at >= ?", Time.zone.now) }
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,6 +4,8 @@
 # like bio, status, handle, twitch, YouTube, etc
 # Becomes friends with other Profiles through Friendship
 class Profile < ApplicationRecord
+  include ::Handleable
+
   belongs_to :user
 
   has_many :event_attendees, dependent: :destroy
@@ -13,9 +15,6 @@ class Profile < ApplicationRecord
   # Whether they are "buddy" or "friend"
   has_many :buddyships, class_name: "Friendship", foreign_key: "buddy_id", dependent: :destroy, inverse_of: :buddy
   has_many :friendships, class_name: "Friendship", foreign_key: "friend_id", dependent: :destroy, inverse_of: :friend
-  validates :handle, presence: true,
-                     format: { with: /\A[a-zA-Z0-9]+\z/, message: "Only letters and numbers are allowed" },
-                     uniqueness: { case_sensitive: true }
 
   def to_s
     name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,17 @@ en:
   time:
     formats:
       time: "%H:%M"
+  activerecord:
+    errors:
+      models:
+        event:
+          attributes:
+            handle:
+              invalid: "only letters and numbers are allowed"
+        profile:
+          attributes:
+            handle:
+              invalid: "only letters and numbers are allowed"
   event_attendees:
     list:
       buddies_attending:

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -5,6 +5,22 @@ require "rails_helper"
 RSpec.describe Profile, type: :model do
   let(:profile) { create :profile }
 
+  describe "validations" do
+    it "has a valid factory" do
+      expect(profile).to be_valid
+    end
+
+    context "with duplicate handle" do
+      let(:duplicate_handle) { build :profile, handle: profile.handle.downcase }
+
+      it "does not allow two profiles to have the same handle" do
+        profile
+        duplicate_handle.valid?
+        expect(duplicate_handle.errors.full_messages).to include("Handle has already been taken")
+      end
+    end
+  end
+
   describe "#attending?" do
     subject { profile.attending? event }
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe "/events", type: :request do
     end
   end
 
+  describe "GET /show with handle" do
+    subject(:get_show) { get "/events/#{event.handle}" }
+
+    let(:event) { create :event }
+
+    it "renders a successful response" do
+      get_show
+      expect(response).to be_successful
+    end
+  end
+
   describe "GET /new" do
     subject(:get_new) { get new_event_url }
 

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe "/profiles", type: :request do
     end
   end
 
+  describe "GET /show with handle" do
+    subject(:get_show) { get "/profiles/#{profile.handle}" }
+
+    it "renders a successful response" do
+      get_show
+      expect(response).to be_successful
+    end
+  end
+
   describe "GET /new" do
     subject(:get_new) { get new_profile_url }
 

--- a/spec/routing/profiles_routing_spec.rb
+++ b/spec/routing/profiles_routing_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe ProfilesController, type: :routing do
       expect(get: "/profiles/1").to route_to("profiles#show", id: "1")
     end
 
+    it "routes to #show with handle" do
+      expect(get: "/profiles/chaelcodes").to route_to("profiles#show", id: "chaelcodes")
+    end
+
     it "routes to #edit" do
       expect(get: "/profiles/1/edit").to route_to("profiles#edit", id: "1")
     end


### PR DESCRIPTION
# Description
I think it'd be rad if we could just type in "/profiles/rubyconf" and be directed to the RubyConf event! It'd certainly make accessing events and profiles easier.

# Changes
- Profiles and Events have handles that are case insensitive.
- On the Profile and Event, a user can just call /profiles/ChaelCodes and be routed to my profile!