### PR TITLE
Restrict CI executions on push to 'main' branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,11 @@
 name: Check Code
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+      
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
Currently some Github Actons checks run twice. This change should fix this, as push trigger will be now restricted only to 'main' branch while leaving pull request trigger as it was.﻿
