### PR TITLE
 #97: Tech Debt: unconfirmed UserFactory

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,6 +20,14 @@ FactoryBot.define do
       end
     end
 
+    trait :overdue_unconfirmed do
+      confirmed_at { nil }
+      after(:create) do |user|
+        # Overwrite confirmation_sent_at
+        user.update(confirmation_sent_at: 2.days.ago)
+      end
+    end
+
     trait :admin do
       admin { true }
     end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -29,6 +29,14 @@ describe "Users" do
     end
   end
 
+  context "when overdue_unconfirmed user logged in does not match" do
+    let(:user) { create(:user, :overdue_unconfirmed) }
+
+    it "permission to edit denied" do
+      expect(page).to have_content "You are not authorized to perform this action."
+    end
+  end
+
   context "when user unconfirmed" do
     let(:user) { create(:user, :unconfirmed) }
 

--- a/spec/requests/event_attendees_spec.rb
+++ b/spec/requests/event_attendees_spec.rb
@@ -123,6 +123,43 @@ RSpec.describe "/event_attendees", type: :request do
       end
     end
 
+    context "with valid parameters and overdue_unconfirmed user" do
+      let(:user) { create :user, :overdue_unconfirmed }
+      let(:profile) { create :profile, user: user }
+
+      let(:attributes) do
+        {
+          profile_id: profile.id,
+          event_id: create(:event).id
+        }
+      end
+
+      it "creates a new EventAttendee" do
+        expect { post_create }.to change(EventAttendee, :count).by(1)
+      end
+
+      it "redirects to the created event_attendee" do
+        post_create
+        expect(response).to redirect_to(event_attendee_url(EventAttendee.last))
+      end
+    end
+
+    context "with valid parameters and unconfirmed user" do
+      let(:user) { create :user, :unconfirmed }
+      let(:profile) { create :profile, user: user }
+
+      let(:attributes) do
+        {
+          profile_id: profile.id,
+          event_id: create(:event).id
+        }
+      end
+
+      it "creates a new EventAttendee" do
+        expect { post_create }.to change(EventAttendee, :count).by(0)
+      end
+    end
+
     context "with invalid parameters and valid user" do
       let(:attributes) { { profile_id: profile.id } }
       let(:profile) { create(:profile) }

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -18,9 +18,20 @@ RSpec.describe "/profiles", type: :request do
 
     let!(:profile) { create :profile }
 
-    it "renders a successful response" do
-      get_index
-      expect(response.body).to include(profile.name)
+    context "when the profile belongs to a confirmed user" do
+      it "renders a successful response" do
+        get_index
+        expect(response.body).to include(profile.name)
+      end
+    end
+
+    context "when the profile belongs to a confirmed overdue_unconfirmed user" do
+      let(:user) { create :user, :overdue_unconfirmed }
+
+      it "renders a successful response" do
+        get_index
+        expect(response.body).to include(profile.name)
+      end
     end
   end
 
@@ -184,6 +195,25 @@ RSpec.describe "/profiles", type: :request do
           handle: "ChaelCodes"
         }
       end
+
+      it "creates a new Profile" do
+        expect { post_create }.to change(Profile, :count).by(1)
+      end
+
+      it "redirects to the created profile" do
+        post_create
+        expect(response).to redirect_to(profile_url(Profile.last))
+      end
+    end
+
+    context "with valid parameters and overdue_unconfirmed user" do
+      let(:attributes) do
+        {
+          handle: "ChaelCodes"
+        }
+      end
+
+      let(:user) { create :user, :overdue_unconfirmed }
 
       it "creates a new Profile" do
         expect { post_create }.to change(Profile, :count).by(1)


### PR DESCRIPTION
## Description of Feature or Issue
closes #97 

## Checklist
- [x] Added/changed specs for the changes made
- [x] Is the linting build successful?
- [x] Is the test build successful?

## User-Facing Changes
new tests that prove an unconfirmed user can create a profile, attend events, and view profiles.
