### PR TITLE
Add SendGrid to Deployment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "conf_buddies_production"
 
-  config.action_mailer.default_url_options = { host: "confbuddies.herokuapp.com" }
+  config.action_mailer.default_url_options = { host: "meetanotherday.onrender.com" }
   config.action_mailer.smtp_settings = {
     port: ENV.fetch("SENDGRID_PORT", nil),
     address: ENV.fetch("SENDGRID_SERVER", nil),

--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,7 @@ services:
   - type: web
     name: MeetAnotherDay
     runtime: ruby
-    plan: free
+    plan: starter
     buildCommand: "./bin/render-build.sh"
     # preDeployCommand: "bundle exec rails db:migrate" # preDeployCommand only available on paid instance types
     startCommand: "bundle exec rails server"
@@ -18,5 +18,9 @@ services:
           property: connectionString
       - key: SECRET_KEY_BASE
         generateValue: true
+      - key: SENDGRID_PASSWORD
+      - key: SENDGRID_PORT
+      - key: SENDGRID_SERVER
+      - key: SENDGRID_USERNAME
       - key: WEB_CONCURRENCY
         value: 2 # sensible default


### PR DESCRIPTION
## Description of Feature or Issue
closes # 217

We need SendGrid to handle email confirmation during account creation, and it'll be used to send emails out notifying users before an event.

The plan for the webservice was upgraded to starter, so that's been reflected in the render.yml as well.

## Checklist
- [x] Added/changed specs for the changes made
- [x] Is the linting build successful?
- [x] Is the test build successful?