### PR TITLE
Remove name and bio from seeds

### DIFF
--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -2,15 +2,11 @@
 
 users = [
   {
-    bio: "Hello. I am admin. Friends please? Ty.",
     email: "admin@example.com",
-    name: "Chael",
     admin: true
   },
   {
-    bio: "Hello. I am dev. Friends please? Ty.",
     email: "john@example.com",
-    name: "John",
     admin: false
   },
   {


### PR DESCRIPTION
## Description of Feature or Issue
closes #212 

Seeds produced the error:
```
PG::UndefinedColumn: ERROR:  column users.bio does not exist (PG::UndefinedColumn)
LINE 1: SELECT "users".* FROM "users" WHERE "users"."bio" = $1 AND "...
```
Because we removed name/bio from Users table. Remove these fields to fix seeds!

## Checklist
- [x] Added/changed specs for the changes made
- [x] Is the linting build successful?
- [x] Is the test build successful?
