### PR TITLE
Support viewing past events on the Events index page.

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,7 +7,7 @@ class EventsController < ApplicationController
 
   # GET /events or /events.json
   def index
-    @events = Event.ongoing_or_upcoming
+    @events = params[:past] ? Event.past : Event.ongoing_or_upcoming
     return unless current_profile
     @friends_attending_count = {}
     @events.each do |event|

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,7 @@ class Event < ApplicationRecord
   validates_comparison_of :end_at, greater_than: :start_at
 
   scope :ongoing_or_upcoming, -> { where("end_at >= ?", Time.zone.now) }
+  scope :past, -> { where("end_at < ?", Time.zone.now) }
 
   def to_s
     name

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,5 +1,10 @@
 <div class="section container">
-  <h1 class="title">Events</h1>
+  <h1 class="title"><%= params[:past] ? 'Past Events' : 'Events' %></h1>
   <%= render 'list', events: @events %>
+  <% if params[:past] %>
+    <%= link_to 'Upcoming and Ongoing Events', events_path, class: "button is-primary" %>
+  <% else %>
+    <%= link_to 'Past Events', events_path(past: true), class: "button is-primary" %>
+  <% end %>
   <%= link_to 'New Event', new_event_path, class: "button is-primary" if policy(:event).new? %>
 </div>

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -32,4 +32,16 @@ RSpec.describe Event do
     it { is_expected.to include(ongoing_event) }
     it { is_expected.not_to include(past_event) }
   end
+
+  describe "#past" do
+    subject { described_class.past }
+
+    let!(:past_event) { create :event, :past_event }
+    let!(:upcoming_event) { create :event, start_at: 3.days.from_now, end_at: 5.days.from_now }
+    let!(:ongoing_event) { create :event, start_at: 3.days.ago, end_at: 1.day.from_now }
+
+    it { is_expected.not_to include(upcoming_event) }
+    it { is_expected.not_to include(ongoing_event) }
+    it { is_expected.to include(past_event) }
+  end
 end


### PR DESCRIPTION
## Description of Feature or Issue
Allow users to view past events.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
There's a new "Past Events" button on the Events page.
<img width="923" alt="Screenshot of new Past Events button" src="https://github.com/user-attachments/assets/5cf9f23e-937a-435b-b26d-009ea168578e" />

When clicked, it shows the user past events, and there's a new button to get back to "Upcoming and Ongoing Events".
<img width="808" alt="Screenshot of Past Events view" src="https://github.com/user-attachments/assets/f4ac7bc5-ac3a-4dda-972f-5bcce923c842" />

