### PR TITLE
Add Devcontainer for dev environments.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+	"name": "Meet Another Day Dev Container",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "web",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/app",
+ 
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000]
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  web:
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - ../..:/workspaces:cached
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+ 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,21 @@ Prerequisites - 'ruby-3.2.2' and 'postgresql' for database
 # Dev Environment Setup (Using Docker)
 This application has a development environment that supports Docker. We believe this makes it easier to get started with the application.
 To get started, you will need either Docker [desktop](https://docs.docker.com/desktop/#download-and-install) or Docker [engine](https://docs.docker.com/engine/install) as well as
-Docker Compose which is a tool that is used for defining and running multi-container Docker applications. In our case for running the web application, database and selenium for testing,
+Docker Compose which is a tool that is used for defining and running multi-container Docker applications. In our case for running the web application, database and selenium for testing.
 
 Please note:
 Older versions of Docker that were released before version 2 and the [new docker compose command](https://docs.docker.com/compose/cli-command/#compose-v2-and-the-new-docker-compose-command) will have to use a hyphen in these commands instead.
 For example running `docker-compose` instead of `docker compose` listed in the examples below.
+
+## Dev Containers
+If you are using VS Code, we have a devcontainer setup, which allows you to interact with a dockerized dev environment like it's a local environment!
+Install the Dev Containers extension, and reopen the folder in a container.
+`gh auth login` will handle auth with github. Please use the same protocol as you used to clone the repo (ssh or https).
+Once you are within the dev container - all commands will be run within the docker container, but you do not need to prepend docker compose.
+Just use `bundle exec rspec`, `bundle exec rails c` or any other commands as normal.
+The server should be running and forwarded to [localhost:3000](localhost:3000).
+Extensions in your editor that rely on libraries inside the container - test runners, ruby lsp, and herb will all run perfectly.
+You may need to reenable extensions to run inside the container.
 
 ## Working with the repository
 <details>
@@ -99,6 +109,18 @@ web_1           | ========================================
 If you update package.json or yarn.lock you'll want to rebuild that module. There might be a more efficient way, but you can run:
 ```
 > docker compose run --rm web yarn install --check-files
+```
+
+## Updating or adding gems
+
+Run this command or edit Gemfile to add the gem you want.
+```
+> docker compose run --rm web bundle add rails_cloudflare_turnstile
+```
+
+Rebuild container.
+```
+> docker compose up -d --build
 ```
 
 ## Running Migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
-FROM ruby:3.2.2-alpine
+FROM ruby:3.2.2
 
-RUN apk update && apk upgrade && apk add --update --no-cache \
-  build-base \
-  nodejs \
-  postgresql-dev \
-  tzdata \
-  yarn && rm -rf /var/cache/apk/*
+RUN apt-get update
 
 COPY Gemfile Gemfile.lock /app/
 


### PR DESCRIPTION
## Description of Feature or Issue

Added devcontainers for easier contributions. Now developers can treat the docker environment like a dev environment. The alpine ruby image had to be replaced with the base ruby image to add support for things like bash and ssh. I'm using the github cli to control auth because forwarding my git credentials didn't work.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<!-- If there have been user facing change please include screenshots -->
