### PR TITLE
Fix git error with dubious ownership

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,9 @@
 		"../docker-compose.yml"
 	],
 
+	// git does not recognize the user in a devcontainer - https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "web",


### PR DESCRIPTION
## Description of Feature or Issue

git was producting an error:
fatal: detected dubious ownership in repository at '/app' To add an exception for this directory, call:

    git config --global --add safe.directory /app

This is caused by ownership confusion between the devcontainer, docker, and the cloned repository locally.

The solution is to run the configuration command in the devcontainer.

Followed this blog post: https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<!-- If there have been user facing change please include screenshots -->
