### PR TITLE
Add Pagination to Events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rails", "~> 7.1"
 gem "devise" # Use to authenticate user
 gem "jsbundling-rails", "~> 1.3.0" # bundle js using webpack - https://github.com/rails/jsbundling-rails
 gem "kramdown", "~> 2.3", ">= 2.3.1" # Parse Markdown on Profile/Event pages
+gem "pagy", "~> 9.3"
 gem "pg", "~> 1.1" # Use postgresql as the database for Active Record
 gem "puma", "~> 6" # Use Puma as the app server
 gem "pundit" # use pundit to control app premissions and policies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pagy (9.3.5)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -357,6 +358,7 @@ DEPENDENCIES
   jsbundling-rails (~> 1.3.0)
   kramdown (~> 2.3, >= 2.3.1)
   listen (~> 3.3)
+  pagy (~> 9.3)
   pg (~> 1.1)
   pry
   puma (~> 6)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,9 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!, only: %i[create new update edit destroy]
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
+  # Add Pagination
+  include Pagy::Backend
+
   # TODO: logged out users don't count notifications
   before_action :notification_count
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,10 +4,10 @@
 class EventsController < ApplicationController
   before_action :create_event, only: :create
   before_action :set_event, only: %i[show edit update destroy]
+  before_action :set_events, only: :index
 
   # GET /events or /events.json
   def index
-    @events = params[:past] ? Event.past : Event.ongoing_or_upcoming
     return unless current_profile
     @friends_attending_count = {}
     @events.each do |event|
@@ -85,6 +85,13 @@ class EventsController < ApplicationController
     @event = Event.find_by("LOWER(handle) = ?", params[:id]&.downcase)
     @event ||= Event.find(params[:id])
     authorize @event
+  end
+
+  def set_events
+    @all_events = params[:past] ? Event.past : Event.ongoing_or_upcoming
+    @all_events = @all_events.order(:start_at)
+    @pagy, @events = pagy(@all_events, page_param: :number)
+    @pagination_links = pagy_jsonapi_links(@pagy, absolute: true)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,6 +5,7 @@ class ProfilesController < ApplicationController
   before_action :authenticate_user!, except: [:show]
   before_action :set_profile, only: %i[show edit update destroy]
   before_action :new_profile, only: :create
+  before_action :set_events, only: :show
 
   # GET /profiles or /profiles.json
   def index
@@ -13,7 +14,6 @@ class ProfilesController < ApplicationController
 
   # GET /profiles/1 or /profiles/1.json
   def show
-    @events = @profile.events if policy(@profile).show_details?
     @your_friendship = Friendship.find_or_initialize_by buddy: current_profile, friend: @profile
     @your_friendship = nil unless @your_friendship.valid? && policy(@your_friendship).show?
     @their_friendship = Friendship.find_or_initialize_by friend: current_profile, buddy: @profile
@@ -65,6 +65,11 @@ class ProfilesController < ApplicationController
   end
 
   private
+
+  def set_events
+    @all_events = policy(@profile).show_details? ? @profile.events : Event.none
+    @events_pagy, @events = pagy(@all_events)
+  end
 
   def new_profile
     @profile = Profile.new(profile_params)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,9 @@
 
 # Any needed Application UI functions
 module ApplicationHelper
+  # Add pagination helpers
+  include Pagy::Frontend
+
   # Display buttons for the show page
   def buttons(resource, include_nav: false, include_show: false)
     buttons = []

--- a/app/views/events/_event.json.jbuilder
+++ b/app/views/events/_event.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! event, :id, :name, :description, :start_at, :end_at, :created_at, :updated_at
+json.extract! event, :id, :name, :description, :handle, :start_at, :end_at, :created_at, :updated_at
 json.url event_url(event, format: :json)

--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -1,11 +1,10 @@
 <% unless events&.any? %>
   <p>There are no events to display.</p>
 <% else %>
-  <table class="table">
+  <table class="table is-fullwidth">
     <thead>
       <tr>
         <th>Name</th>
-        <th class="is-hidden-mobile">Description</th>
         <% if @friends_attending_count %>
           <th colspan="3"></th>
         <% end %>
@@ -17,7 +16,6 @@
       <% events.each do |event| %>
         <tr>
           <td><%= link_to event %></td>
-          <td class="is-hidden-mobile"><%= kramdown_pure_text(event.description) %></td>
           <% if @friends_attending_count %>
             <td><%= "#{@friends_attending_count[event.id]} Friends Attending." %></td>
           <% end %>
@@ -28,3 +26,5 @@
     </tbody>
   </table>
 <% end %>
+
+<%== pagy_bulma_nav(pagy) if pagy.pages > 1 %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,6 +1,7 @@
 <div class="section container">
   <h1 class="title"><%= params[:past] ? 'Past Events' : 'Events' %></h1>
-  <%= render 'list', events: @events %>
+  <%= render 'list', events: @events, pagy: @pagy %>
+
   <% if params[:past] %>
     <%= link_to 'Upcoming and Ongoing Events', events_path, class: "button is-primary" %>
   <% else %>

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,1 +1,4 @@
-json.array! @events, partial: "events/event", as: :event
+json.events do
+  json.array! @events, partial: "events/event", as: :event
+end
+json.links @pagination_links

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -22,11 +22,11 @@
     </div>
   </div>
 </div>
-<% if policy(@profile).show_details? %>
+<% if policy(@profile).show_details? && @events.size > 0 %>
   <div class="section">
     <div class="container">
       <div class="block">
-        <%= render 'events/list', events: @events %>
+        <%= render 'events/list', events: @events, pagy: @events_pagy %>
       </div>
     </div>
   </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Optionally override some pagy default with your own in the pagy initializer
+Pagy::DEFAULT[:limit] = 10 # items per page
+Pagy::DEFAULT[:size]  = 5 # nav bar links
+# Better user experience handled automatically
+require 'pagy/extras/overflow'
+Pagy::DEFAULT[:overflow] = :last_page
+require 'pagy/extras/bulma'
+require 'pagy/extras/jsonapi'
+# require 'pagy/extras/limit'

--- a/db/seeds/development/events.seeds.rb
+++ b/db/seeds/development/events.seeds.rb
@@ -15,6 +15,69 @@ after "development:profiles" do
       description: "Best place to meet javascript people",
       start_at: 10.days.from_now,
       end_at: 13.days.from_now
+    },
+    {
+      name: "ContainerDays 2023",
+      handle: "container_days_2023",
+      description: "Description",
+      start_at: Date.new(2023, 9, 11),
+      end_at: Date.new(2023, 9, 13)
+    },
+    {
+      name: "KCD Munich 2024",
+      handle: "container_days_2024",
+      description: "Description",
+      start_at: Date.new(2024, 7, 1),
+      end_at: Date.new(2024, 7, 2)
+    },
+    {
+      name: "RubyConf Taiwan x COSCUP 2025",
+      handle: "rubyconf_taiwan_2025",
+      description: "Description",
+      start_at: Date.new(2025, 8, 9),
+      end_at: Date.new(2025, 8, 10)
+    },
+    {
+      name: "San Francisco Ruby Conference 2025",
+      handle: "sf_ruby_conf_2025",
+      description: "Description",
+      start_at: Date.new(2025, 11, 19),
+      end_at: Date.new(2025, 11, 20)
+    },
+    {
+      name: "Rails Camp West 2025",
+      handle: "rails_camp_2025",
+      description: "description",
+      start_at: Date.new(2025, 8, 18),
+      end_at: Date.new(2025, 8, 21)
+    },
+    {
+      name: "RailsConf 2025",
+      handle: "railsconf_2025",
+      description: "description",
+      start_at: Date.new(2025, 8, 8),
+      end_at: Date.new(2025, 8, 10)
+    },
+    {
+      name: "Brighton Ruby 2025",
+      handle: "brighton_ruby_2025",
+      description: "Description",
+      start_at: Date.new(2025, 6, 19),
+      end_at: Date.new(2025, 6, 19)
+    },
+    {
+      name: "Ruby Retreat 2025",
+      handle: "ruby_retreat_2025",
+      description: "Description",
+      start_at: Date.new(2025, 5, 9),
+      end_at: Date.new(2025, 5, 12)
+    },
+    {
+      name: "XO Ruby Atlanta 2025",
+      handle: "xo_ruby_atl_2025",
+      description: "Description",
+      start_at: Date.new(2025, 9, 13),
+      end_at: Date.new(2025, 9, 13)
     }
   ]
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -10,11 +10,83 @@ RSpec.describe "/events" do
   end
 
   describe "GET /index" do
-    let!(:event) { create :event }
+    subject { get events_url, params: params.merge(format: :json) }
 
-    it "renders a successful response" do
-      get events_url
-      expect(response.body).to include(event.name)
+    let(:params) { {} }
+
+    context "with no events" do
+      it "renders a successful response" do
+        subject
+        expect(json_body["events"]).to be_empty
+      end
+    end
+
+    context "with events" do
+      let!(:past_event) { create :event, :past_event }
+      let!(:past_event2) { create :event, :past_event }
+      let!(:future_event) { create :event }
+
+      it "renders a list of only future events", :aggregate_failures do
+        subject
+        events = json_body["events"]
+        event_handles = events.pluck "handle"
+        expect(events.count).to eq 1
+        expect(event_handles).to include future_event.handle
+        expect(event_handles).not_to include past_event.handle
+      end
+
+      context "with 10+ events" do
+        let!(:events) { create_list :event, 11 }
+
+        it "paginates the list", :aggregate_failures do
+          subject
+          events = json_body["events"]
+          links = json_body["links"]
+          expect(events.count).to eq 10
+          expect(links["first"]).to eq "http://www.example.com/events?format=json&page%5Bnumber%5D=1"
+          expect(links["last"]).to eq "http://www.example.com/events?format=json&page%5Bnumber%5D=2"
+          expect(links["prev"]).to be_nil
+          expect(links["next"]).to eq "http://www.example.com/events?format=json&page%5Bnumber%5D=2"
+        end
+
+        context "when second page" do
+          let(:params) { { page: { number: 2 } } }
+
+          it "paginates the list", :aggregate_failures do
+            subject
+            events = json_body["events"]
+            links = json_body["links"]
+            expect(events.count).to eq 2
+            expect(links["first"]).to eq "http://www.example.com/events?page%5Bnumber%5D=1&format=json"
+            expect(links["last"]).to eq "http://www.example.com/events?page%5Bnumber%5D=2&format=json"
+            expect(links["prev"]).to eq "http://www.example.com/events?page%5Bnumber%5D=1&format=json"
+            expect(links["next"]).to be_nil
+          end
+        end
+
+        context "when limit is passed", skip: "Limits are not working - I need to ask for help" do
+          let(:params) { { page: { size: 5 } } }
+
+          it "paginates in chunks of 5" do
+            subject
+            events = json_body["events"]
+            expect(events.count).to eq 5
+          end
+        end
+      end
+
+      context "with past events parameter" do
+        let(:params) { { past: true } }
+
+        it "renders a list of only past events", :aggregate_failures do
+          subject
+          events = json_body["events"]
+          event_handles = events.pluck "handle"
+          expect(events.count).to eq 2
+          expect(event_handles).to include past_event.handle
+          expect(event_handles).not_to include future_event.handle
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Description of Feature or Issue

Events should be paginated in some way. This PR adds pagination to events on the profile and events index page using the pagy gem.

/events.json returns a valid pagination response with links and wraps array of events in "events" tag.

Added new events to the seedfile to make testing pagination easier.

## Checklist
- [x] Added/changed specs for the changes made
- [x] Is the linting build successful?
- [x] Is the test build successful?

## Resources
- https://ddnexus.github.io/pagy/docs/api/frontend/
- https://github.com/ddnexus/pagy?tab=readme-ov-file#-its-easy-to-use-and-customize
- https://bulma.io/documentation/components/pagination/
- https://jsonapi.org/format/#fetching-pagination

## User-Facing Changes

<img width="962" height="610" alt="events list with pagination navigation at the bottom" src="https://github.com/user-attachments/assets/d87e08b0-6a70-4bc8-bfcf-bfd5bfd4ab72" />
<img width="953" height="833" alt="events list on the profile with navigation at the bottom" src="https://github.com/user-attachments/assets/324d03f5-4fa4-4802-be75-d2a96be4d71b" />

API Changes:

```
{
  "events": [
    {
      "id": 4,
      "name": "San Francisco Ruby Conference 2025",
      "description": "Description",
      "handle": "sf_ruby_conf_2025",
      "start_at": "2025-11-19T00:00:00.000Z",
      "end_at": "2025-11-20T00:00:00.000Z",
      "created_at": "2025-08-03T16:07:56.082Z",
      "updated_at": "2025-08-03T16:07:56.082Z",
      "url": "http://localhost:3000/events/4.json"
    }
  ],
  "links": {
    "first": "http://localhost:3000/events.json?page%5Bpage%5D=1",
    "last": "http://localhost:3000/events.json?page%5Bpage%5D=2",
    "prev": "http://localhost:3000/events.json?page%5Bpage%5D=1",
    "next": null
  }
}
```
