### PR TITLE
UI Update

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,7 @@
     <%= csp_meta_tag %>
 
     <%= favicon_link_tag asset_path("favicon.png") %>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
-    <link rel="stylesheet" href="https://unpkg.com/bulmaswatch/cyborg/bulmaswatch.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%#= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>


### PR DESCRIPTION
## Description of Feature or Issue

Swap to Bulma 1.0.4 and get rid of cyborg theme.

The new Bulma theme respects dark/light mode preferences and looks slick.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<img width="1420" height="839" alt="Screenshot of new UI on the about page which shows the old theme." src="https://github.com/user-attachments/assets/5950c6ff-d800-401e-980a-e2216454b7c5" />

