### PR TITLE
Allow users to update the 'email_scheduled_on' field.

### DIFF
--- a/app/controllers/event_attendees_controller.rb
+++ b/app/controllers/event_attendees_controller.rb
@@ -74,6 +74,6 @@ class EventAttendeesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def event_attendee_params
-    params.require(:event_attendee).permit(:profile_id, :event_id, :organizer)
+    params.require(:event_attendee).permit(:profile_id, :event_id, :email_scheduled_on, :organizer)
   end
 end

--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -22,6 +22,12 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
     end
   end
 
+  def labelled_date_field(method, label_options: {}, input_options: {}, help: "")
+    form_controls(method, label_options, help) do
+      date_field(method, input_options)
+    end
+  end
+
   def labelled_number_field(method, label_options: {}, input_options: {}, help: "")
     form_controls(method, label_options, help) do
       number_field(method, input_options)

--- a/app/policies/event_attendee_policy.rb
+++ b/app/policies/event_attendee_policy.rb
@@ -13,6 +13,8 @@ class EventAttendeePolicy < ApplicationPolicy
     ProfilePolicy.new(user, @profile).show_details?
   end
 
+  # Allows users to see the index page, which currently only shows their records
+  # but the scope will filter to only those they should see
   def index?
     true
   end
@@ -26,14 +28,14 @@ class EventAttendeePolicy < ApplicationPolicy
   end
 
   def update?
-    false
+    profile.user == user
   end
 
   def destroy?
     profile.user == user
   end
 
-  # Rules governing a list of Events
+  # Rules governing a list of EventAttendees
   class Scope < Scope
     def resolve
       scope.where(profile: ProfilePolicy::Scope.new(user, Profile).resolve)

--- a/app/views/event_attendees/_form.html.erb
+++ b/app/views/event_attendees/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: event_attendee) do |form| %>
+<%= form_with(model: event_attendee, builder: ApplicationFormBuilder) do |form| %>
   <% if event_attendee.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(event_attendee.errors.count, "error") %> prohibited this event_attendee from being saved:</h2>
@@ -21,6 +21,8 @@
     <%= form.collection_select :event_id, Event.all, :id, :name %>
   </div>
 
+  <%= form.labelled_date_field :email_scheduled_on, help: "The date you'll receive your event reminder email." %>
+
   <div class="field">
     <%= form.label :organizer %>
     <%= form.check_box :organizer %>
@@ -29,5 +31,4 @@
   <div class="actions">
     <%= form.submit %>
   </div>
-
 <% end %>

--- a/app/views/event_attendees/edit.html.erb
+++ b/app/views/event_attendees/edit.html.erb
@@ -1,6 +1,11 @@
-<h1>Editing Event Attendee</h1>
+<div class="section">
+  <h1 class="title">Editing Event Attendee</h1>
 
-<%= render 'form', event_attendee: @event_attendee %>
+  <div class="block">
+    <%= render 'form', event_attendee: @event_attendee %>
+  </div>
 
-<%= link_to 'Show', @event_attendee %> |
-<%= link_to 'Back', event_attendees_path %>
+  <div class="block">
+    <%= buttons(@event_attendee) %>
+  </div>
+</div>

--- a/app/views/event_attendees/show.html.erb
+++ b/app/views/event_attendees/show.html.erb
@@ -1,23 +1,23 @@
 <div class="section">
   <div class="container">
     <div class="block">
-    <p>
-      <strong>Profile:</strong>
-      <%= link_to @event_attendee.profile %>
-    </p>
+      <p>
+        <strong>Profile</strong>
+        <%= link_to @event_attendee.profile %>
+      </p>
 
-    <p>
-      <strong>Event:</strong>
-      <%= link_to @event_attendee.event %>
-    </p>
+      <p>
+        <strong>Event</strong>
+        <%= link_to @event_attendee.event %>
+      </p>
 
-    <p>
-      <strong>Email scheduled on:</strong>
-      <%= @event_attendee.email_scheduled_on.present? ? l(@event_attendee.email_scheduled_on, format: :long) : "Not scheduled" %>
-    </p>
+      <p>
+        <strong>Email scheduled on</strong>
+        <%= @event_attendee.email_scheduled_on.present? ? l(@event_attendee.email_scheduled_on, format: :long) : "Not scheduled" %>
+      </p>
     </div>
     <div class="block">
-    <%= buttons(@event_attendee) %>
+      <%= buttons(@event_attendee) %>
     </div>
   </div>
 </div>

--- a/spec/policies/event_attendee_policy_spec.rb
+++ b/spec/policies/event_attendee_policy_spec.rb
@@ -3,6 +3,51 @@
 require "rails_helper"
 
 describe EventAttendeePolicy, type: :policy do
+  # Permissions should match show_details on the profile
+  permissions :show? do
+    context "with viewing event attendee" do
+      let(:event_attendee) { build :event_attendee }
+
+      context "with no user" do
+        it { expect(described_class).not_to permit(nil, event_attendee) }
+      end
+
+      context "with unconfirmed user" do
+        let(:user) { create :user, :unconfirmed }
+
+        it { expect(described_class).not_to permit(user, event_attendee) }
+      end
+
+      context "with confirmed user" do
+        let(:user) { create :user }
+
+        it { expect(described_class).to permit(user, event_attendee) }
+      end
+
+      context "with admin" do
+        let(:user) { create :user, :admin }
+
+        it { expect(described_class).to permit(user, event_attendee) }
+      end
+    end
+  end
+
+  permissions :update? do
+    let(:event_attendee) { build :event_attendee }
+
+    context "with profile matching current profile" do
+      let(:user) { event_attendee.profile.user }
+
+      it { expect(described_class).to permit(user, event_attendee) }
+    end
+
+    context "with profile not matching current profile" do
+      let(:user) { create :user }
+
+      it { expect(described_class).not_to permit(user, event_attendee) }
+    end
+  end
+
   permissions ".scope?" do
     subject { Pundit.policy_scope(user, EventAttendee.all) }
 


### PR DESCRIPTION
## Description of Feature or Issue

Allow users to update the email_scheduled_on field.
This will allow us to test the rake task earlier, but also allow users to set a custom date to receive their event reminder email.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<!-- If there have been user facing change please include screenshots -->
