### PR TITLE
Block blocked profiles from viewing the profile

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -17,7 +17,7 @@ class ProfilesController < ApplicationController
     @your_friendship = Friendship.find_or_initialize_by buddy: current_profile, friend: @profile
     @your_friendship = nil unless @your_friendship.valid? && policy(@your_friendship).show?
     @their_friendship = Friendship.find_or_initialize_by friend: current_profile, buddy: @profile
-    @their_friendship = nil unless @their_friendship.valid? && policy(@their_friendship).show?
+    @their_friendship = nil unless @their_friendship.valid?
   end
 
   # GET /profiles/new

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -4,7 +4,7 @@
 module ProfilesHelper
   UNAUTHORIZED_PROFILE_MESSAGES = {
     everyone: "",
-    authenticated: "You must be logged in, and you email confirmed to view this profile.",
+    authenticated: "You must be logged in, and your email confirmed to view this profile.",
     friends: "You must be friends to view this profile.",
     myself: "This profile is not visible to others at this time."
   }.freeze
@@ -14,7 +14,8 @@ module ProfilesHelper
       "?s=#{size}&d=retro&r=pg"
   end
 
-  def unauthorized_message(profile)
+  def unauthorized_message(profile, blocked: false)
+    return UNAUTHORIZED_PROFILE_MESSAGES[:myself] if blocked
     UNAUTHORIZED_PROFILE_MESSAGES.with_indifferent_access[profile.visibility]
   end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -11,15 +11,17 @@
         </div>
       </div>
       <div class="content">
-        <%= policy(@profile).show_details? ? kramdown(@profile.bio) : unauthorized_message(@profile) %>
+        <%= policy(@profile).show_details? ? kramdown(@profile.bio) : unauthorized_message(@profile, blocked: @their_friendship&.blocked?) %>
       </div>
       <p>
         <%= link_to_if @your_friendship, @your_friendship %>
         <div class="field is-grouped-multiline has-addons">
           <%= friendship_button(@your_friendship, current_user&.profile) %>
         </div>
-        <%= link_to_if @their_friendship, @their_friendship %>
-        <%= friendship_button(@their_friendship, current_user&.profile) %>
+        <% if @their_friendship && policy(@their_friendship).show? %>
+          <%= link_to @their_friendship %>
+          <%= friendship_button(@their_friendship, current_user&.profile) %>
+        <% end %>
       </p>
     </div>
     <% if policy(@profile).show_details? && @events.size > 0 %>

--- a/spec/helpers/profiles_helper_spec.rb
+++ b/spec/helpers/profiles_helper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProfilesHelper do
     context "when visibility is authorized" do
       let(:visibility) { :authenticated }
 
-      it { is_expected.to eq "You must be logged in, and you email confirmed to view this profile." }
+      it { is_expected.to eq "You must be logged in, and your email confirmed to view this profile." }
     end
 
     context "when visibility is friends" do
@@ -35,6 +35,12 @@ RSpec.describe ProfilesHelper do
 
     context "when visibility is myself" do
       let(:visibility) { :myself }
+
+      it { is_expected.to eq "This profile is not visible to others at this time." }
+    end
+
+    context "when blocked is true" do
+      subject { helper.unauthorized_message(profile, blocked: true) }
 
       it { is_expected.to eq "This profile is not visible to others at this time." }
     end

--- a/spec/policies/profile_policy_spec.rb
+++ b/spec/policies/profile_policy_spec.rb
@@ -109,6 +109,14 @@ describe ProfilePolicy, type: :policy do
 
         it { expect(described_class).to permit(user, profile) }
       end
+
+      context "when profile is blocked" do
+        let(:user) { create :user }
+        let(:current_profile) { create :profile, user: }
+        let!(:friendship) { create :friendship, buddy: profile, friend: current_profile, status: :blocked }
+
+        it { expect(described_class).not_to permit(user, profile) }
+      end
     end
 
     context "when viewing authenticated profile" do
@@ -142,6 +150,14 @@ describe ProfilePolicy, type: :policy do
 
         it { expect(described_class).to permit(user, profile) }
       end
+
+      context "when profile is blocked" do
+        let(:user) { create :user }
+        let(:current_profile) { create :profile, user: }
+        let!(:friendship) { create :friendship, buddy: profile, friend: current_profile, status: :blocked }
+
+        it { expect(described_class).not_to permit(user, profile) }
+      end
     end
 
     context "when viewing friends profile" do
@@ -149,6 +165,14 @@ describe ProfilePolicy, type: :policy do
 
       context "with no user" do
         it { expect(described_class).not_to permit(nil, profile) }
+      end
+
+      context "when profile is blocked" do
+        let(:user) { create :user }
+        let(:current_profile) { create :profile, user: }
+        let!(:friendship) { create :friendship, buddy: profile, friend: current_profile, status: :blocked }
+
+        it { expect(described_class).not_to permit(user, profile) }
       end
 
       context "with unconfirmed user" do


### PR DESCRIPTION
## Description of Feature or Issue

While working on refactoring Friendship, we discovered an issue with authenticated and everyone visibility profiles. Both were visible to blocked profiles! 😬

Now, the Profile displays "This profile is not visible to others at this time." which is the same message we see on myself visibility profiles.

We do not tell the blocked profile that they have been blocked to prevent abuse and give the other user plausible deniability in real life.

This can be circumvented by creating a new profile, or in the case of everyone visibility profiles, logging out. But we still want to protect that information if the profile remains logged in, and make accessing that information more difficult.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<img width="712" height="455" alt="screenshot of profile that has blocked me" src="https://github.com/user-attachments/assets/2f9bf771-4441-4650-ba72-d314634da340" />

