### PR TITLE
Bundler caching

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,5 @@
+---
+# Use a cache - save rubygems bandwidth
+BUNDLE_CACHE_ALL: "true"
+# Nokogiri should _behave_
+BUNDLE_FORCE_RUBY_PLATFORM: "true"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.2
+        bundler-cache: true
     - run: bundle install
     - name: Rubocop
       run: bundle exec rubocop
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.2
+        bundler-cache: true
     - run: docker compose run web bundle exec rake db:test:prepare
     - name: RSpec
       run: docker compose run -e CI=true web bundle exec rspec

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-    - run: bundle install
     - name: Rubocop
       run: bundle exec rubocop
   test:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    # Only let github read the repository contents
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
@@ -20,12 +23,40 @@ jobs:
       run: bundle exec rubocop
   test:
     runs-on: ubuntu-latest
+    # Only let github read the repository contents
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-    - run: docker compose run web bundle exec rake db:test:prepare
+    - name: Setup database
+      env:
+        POSTGRES_PASSWORD: password
+      run: |
+        bundle exec rails db:setup
+    - name: Prepare test database
+      env:
+        POSTGRES_PASSWORD: password
+      run: |
+        bundle exec rails db:test:prepare
     - name: RSpec
-      run: docker compose run -e CI=true web bundle exec rspec
-    - run: docker compose down
+      run: bundle exec rspec
+      env:
+        POSTGRES_PASSWORD: password
+        CI: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
@@ -40,7 +40,7 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,7 +34,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+          with:
+            fetch-depth: 30 # Fetch past 30 commits, so all PR commits are included
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,11 +39,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.2
-
-      - name: Install dependencies
-        run: |
-          bundle install
+          bundler-cache: true
 
       - name: Setup database
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,14 +11,15 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 
-# Ignore bundler config.
-/.bundle
-
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+
+# Ignore bundler caches - use caching in CI instead
+/vendor/bundle
+/vendor/cache
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
@@ -31,23 +32,8 @@ config/master.key
 # TODO Comment out this rule if environment variables can be committed
 .env
 
-## Environment normalization:
-/.bundle
-/vendor/bundle
-
-# these should all be checked in to normalize the environment:
-# Gemfile.lock, .ruby-version, .ruby-gemset
-
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
-
-# if using bower-rails ignore default bower_components path bower.json files
-/vendor/assets/bower_components
-*.bowerrc
-bower.json
-
-# Ignore pow environment settings
-.powenv
 
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*

--- a/Gemfile
+++ b/Gemfile
@@ -36,14 +36,13 @@ gem "bootsnap", ">= 1.4.4", require: false
 gem "seedbank"
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "factory_bot"
   gem "factory_bot_rails"
   gem "pry"
   gem "rexml"
   gem "rspec-rails"
   gem "rubocop"
+  gem "rubocop-capybara", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,6 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
-    byebug (11.1.3)
     capybara (3.39.2)
       addressable
       matrix
@@ -352,7 +351,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
-  byebug
   capybara (>= 3.26)
   devise
   factory_bot
@@ -372,6 +370,7 @@ DEPENDENCIES
   rexml
   rspec-rails
   rubocop
+  rubocop-capybara
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # ensures nokogiri uses ruby instead of native extensions so the render build will succeed.
 bundle config set force_ruby_platform true
 
-bundle install
+bundle install --deployment --without development test
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rake db:migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   web:
     build: .
     depends_on:
-      - chrome
       - db
     env_file:
       - config/docker.env
@@ -19,10 +18,6 @@ services:
     volumes:
       - data:/var/lib/postgresql/data
 
-  chrome:
-    image: selenium/standalone-chrome:3.141.59-zirconium # this version should match that of the selenium-webdriver gem (see Gemfile)
-    volumes:
-      - /dev/shm:/dev/shm
 volumes:
   # Volume to hold the Postgres database on the host system
   data:


### PR DESCRIPTION
## Description of Feature or Issue

The goal of this PR is to decrease the runtime for `bundle install` in development, test, and production. As an added bonus, we'll reduce our load on rubygems.org.

We'll do this by caching all our dependencies in vendor/cache by setting up a .bundle/config that says we should cache.

I've manually run `bundle cache`, because initial attempts with the bundle config did not cache.

I tried introducing a new dependency to see if that would help, and the results were unclear.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<!-- If there have been user facing change please include screenshots -->
