### PR TITLE
Make profie and event deletion harder

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,11 +6,11 @@ module ApplicationHelper
   include Pagy::Frontend
 
   # Display buttons for the show page
-  def buttons(resource, include_nav: false, include_show: false)
+  def buttons(resource, include_nav: false, include_show: false, include_delete: false)
     buttons = []
     buttons << show_link(resource) if include_show
     buttons << edit_link(resource)
-    buttons << delete_button(resource)
+    buttons << delete_button(resource) if include_delete
     buttons << index_link(resource) if include_nav
     tag.div(safe_join(buttons), class: "buttons")
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -25,7 +25,7 @@ class EventPolicy < ApplicationPolicy
   # Only Admins can update Events
   def update?
     event_attendee = EventAttendee.find_by(event_id: record&.id, profile_id: user&.profile&.id)
-    user&.admin? or event_attendee&.organizer
+    user&.admin? || event_attendee&.organizer
   end
 
   # Only Admins can destroy Events

--- a/app/policies/profile_policy.rb
+++ b/app/policies/profile_policy.rb
@@ -39,7 +39,7 @@ class ProfilePolicy < ApplicationPolicy
   end
 
   def update?
-    mine?
+    mine? || admin?
   end
 
   def destroy?

--- a/app/views/event_attendees/index.html.erb
+++ b/app/views/event_attendees/index.html.erb
@@ -16,7 +16,7 @@
           <td><%= link_to event_attendee.profile.name, event_attendee.profile %></td>
           <td><%= link_to event_attendee.event.name, event_attendee.event %></td>
           <td>
-            <%= buttons(event_attendee, include_show: true) %>
+            <%= buttons(event_attendee, include_show: true, include_delete: true) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/event_attendees/show.html.erb
+++ b/app/views/event_attendees/show.html.erb
@@ -17,7 +17,7 @@
       </p>
     </div>
     <div class="block">
-      <%= buttons(@event_attendee) %>
+      <%= buttons(@event_attendee, include_delete: true) %>
     </div>
   </div>
 </div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -7,4 +7,18 @@
     <%= link_to 'Show', @event %> |
     <%= link_to 'Back', events_path %>
   </div>
+
+  <% if policy(@event).destroy? %>
+    <section class="section">
+      <div class="box">
+        <h3 class="title is-5 has-text-danger">Danger Zone</h3>
+        <p class="block">
+          Deleting this event is permanent and will remove all attendee registrations. This action cannot be undone.
+        </p>
+        <div class="block">
+          <%= delete_button(@event) %>
+        </div>
+      </div>
+    </section>
+  <% end %>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -40,5 +40,7 @@
     <%= qr_code(event_url(@event)) %>
   </section>
 
-  <div class="section"><%= buttons(@event, include_nav: true) %></div>
+  <div class="section">
+    <%= buttons(@event, include_nav: true, include_delete: false) %>
+  </div>
 </div>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -7,5 +7,5 @@
     </h2>
   <% end %>
 
-  <%= buttons(@notification, include_nav: true) %>
+  <%= buttons(@notification, include_nav: true, include_delete: true) %>
 </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,10 +1,24 @@
 <div class="container">
-  <div class="section">
+  <section class="section">
     <h1>Editing Profile</h1>
 
     <%= render 'form', profile: @profile %>
 
     <%= link_to 'Show', @profile %> |
     <%= link_to 'Back', profiles_path %>
-  </div>
+  </section>
+
+  <% if policy(@profile).destroy? %>
+    <section class="section">
+    <div class="box">
+      <h3 class="title is-5 has-text-danger">Danger Zone</h3>
+      <p class="block">
+        Deleting your profile is permanent and will remove all your event attendance, friendships, and other data. This action cannot be undone.
+      </p>
+      <div class="block">
+        <%= delete_button(@profile) %>
+      </div>
+    </div>
+    </section>
+  <% end %>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -34,7 +34,7 @@
       <%= qr_code(profile_url(@profile)) %>
     </div>
     <div class="block">
-      <%= buttons(@profile, include_nav: true) %>
+      <%= buttons(@profile, include_nav: true, include_delete: false) %>
     </div>
   </div>
 </section>

--- a/spec/features/events/edit_spec.rb
+++ b/spec/features/events/edit_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Edit Event" do
+  let(:event) { create :event }
+  let(:user) { nil }
+
+  before(:each) do
+    sign_in user if user
+    visit(edit_event_path(event))
+  end
+
+  it "does not permit access" do
+    expect(page).to have_content("You need to sign in or sign up before continuing.")
+  end
+
+  context "when user logged in" do
+    let(:user) { create :user }
+
+    it "does not permit access" do
+      expect(page).to have_content("You are not authorized to perform this action.")
+    end
+
+    context "when user is organizer" do
+      let(:profile) { event_attendee.profile }
+      let(:user) { profile.user }
+      let(:event_attendee) { create :event_attendee, event:, organizer: true }
+
+      it "allows user to edit event" do
+        expect(page).to have_content "Editing #{event.name}"
+        expect(page).to have_field "Name"
+        expect(page).to have_field "Description"
+        expect(page).to have_button "Submit"
+        expect(page).not_to have_button "Delete"
+      end
+    end
+
+    context "when user is admin" do
+      let(:user) { create :user, :admin }
+
+      it "allows user to edit and destroy event" do
+        expect(page).to have_content "Editing #{event.name}"
+        expect(page).to have_field "Name"
+        expect(page).to have_field "Description"
+        expect(page).to have_button "Submit"
+        expect(page).to have_content "Danger Zone"
+        expect(page).to have_button "Delete"
+        click_button "Delete"
+        expect(page).to have_content("Event was successfully destroyed.")
+      end
+    end
+  end
+end

--- a/spec/features/events/show_spec.rb
+++ b/spec/features/events/show_spec.rb
@@ -34,7 +34,7 @@ describe "Events" do
       it "allows user to edit and destroy event" do
         expect(page).to have_content "RubyConf"
         expect(page).to have_link "Edit", href: edit_event_path(event)
-        expect(page).to have_button "Delete"
+        expect(page).not_to have_button "Delete"
       end
     end
   end

--- a/spec/features/profiles/edit_spec.rb
+++ b/spec/features/profiles/edit_spec.rb
@@ -26,4 +26,17 @@ describe "Profile" do
       expect(profile.handle).to eq("ChaelChats")
     end
   end
+
+  context "when user is admin" do
+    let(:user) { create :user, :admin }
+
+    it "allows user to destroy profile" do
+      # Do not allow admin to edit profiles
+      expect(page).not_to have_link "Edit", href: edit_profile_path(profile)
+      expect(page).to have_content "Danger Zone"
+      expect(page).to have_button "Delete"
+      click_button "Delete"
+      expect(page).to have_content("Profile was successfully destroyed.")
+    end
+  end
 end

--- a/spec/features/profiles/show_spec.rb
+++ b/spec/features/profiles/show_spec.rb
@@ -53,14 +53,5 @@ describe "Profile" do
         expect(page).to have_link "a link", href: "https://example.com"
       end
     end
-
-    context "when user is admin" do
-      let(:user) { create :user, :admin }
-
-      it "allows user to destroy profile" do
-        expect(page).not_to have_link "Edit", href: edit_profile_path(profile)
-        expect(page).to have_button "Delete"
-      end
-    end
   end
 end

--- a/spec/features/profiles/show_spec.rb
+++ b/spec/features/profiles/show_spec.rb
@@ -41,7 +41,7 @@ describe "Profile" do
 
       it "allows user to edit profile" do
         expect(page).to have_link "Edit", href: edit_profile_path(profile)
-        expect(page).to have_button "Delete"
+        expect(page).not_to have_button "Delete" # Too dangerous, it's on the edit page
       end
     end
 

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -343,12 +343,10 @@ RSpec.describe "/profiles" do
         let(:profile) { create :profile, handle: "Foo" }
         let(:user) { create :user, :admin }
 
-        include_examples "unauthorized access"
-
-        it "does not update the profile" do
+        it "updates the profile" do
           patch_update
           profile.reload
-          expect(profile.handle).to eq "Foo"
+          expect(profile.handle).to eq "ChaelChats"
         end
       end
     end


### PR DESCRIPTION
## Description of Feature or Issue

Right now, a simple misclick could remove your profile and all your friends! Let's make that harder by moving the delete button to the edit page. We should do the same for events.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<!-- If there have been user facing change please include screenshots -->
