### PR TITLE
Extract Notifications/Messages and Add Message to Event Page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,7 @@ class EventsController < ApplicationController
   def show
     return unless current_profile
     @event_attendees = policy_scope(EventAttendee.friends_attending(event: @event, profile: current_profile))
+    @event_attendee = current_user&.profile&.event_attendees&.find_by(event: @event)
   end
 
   # GET /events/new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,9 +16,9 @@ module ApplicationHelper
   end
 
   # Delete Button if the user has permission
-  def delete_button(resource)
+  def delete_button(resource, title: "Delete")
     return unless policy(resource).destroy?
-    button_to("Delete",
+    button_to(title,
               url_for(resource),
               method: :delete,
               data: { confirm: "Are you sure?" },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,22 @@ module ApplicationHelper
               class: "button is-danger")
   end
 
+  def delete_icon(resource)
+    return unless policy(resource).destroy?
+    button_to("",
+              url_for(resource),
+              method: :delete,
+              data: { confirm: "Are you sure?" },
+              form_class: "delete",
+              class: "delete")
+  end
+
+  def error_header(resource)
+    return unless resource.errors.any?
+
+    "#{pluralize(resource.errors.count, 'error')} prohibited this #{resource} from being saved:"
+  end
+
   # Display an icon stored in app/assets/icons
   def icon(name, alt: nil)
     tag.span(class: "icon") do

--- a/app/helpers/event_attendee_helper.rb
+++ b/app/helpers/event_attendee_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# UI helpers for EventAttendee
+module EventAttendeeHelper
+  def attend_event_button(event:, profile:)
+    button_to "Attend",
+              event_attendees_path(
+                event_attendee: {
+                  event_id: event.id,
+                  profile_id: profile.id
+                }
+              ),
+              action: "create",
+              class: "button is-primary"
+  end
+end

--- a/app/views/components/_message.html.erb
+++ b/app/views/components/_message.html.erb
@@ -1,0 +1,17 @@
+<% css_class ||= "" %>
+<% message_header ||= nil %>
+<% resource ||= nil %>
+<% include_delete ||= false %>
+<% include_delete = false unless resource&.persisted? %>
+
+<div class="message <%= css_class %>">
+  <% if message_header %>
+    <div class="message-header">
+      <p><%= message_header %></p>
+      <%= delete_button(resource) if include_delete %>
+    </div>
+  <% end %>
+  <div class="message-body">
+    <%= yield if block_given? %>
+  </div>
+</div>

--- a/app/views/components/_notification.html.erb
+++ b/app/views/components/_notification.html.erb
@@ -1,0 +1,9 @@
+<% css_class ||= "" %>
+<% resource ||= nil %>
+<% include_delete ||= false %>
+<% include_delete = false unless resource&.persisted? %>
+
+<div class="notification <%= css_class %>">
+  <%= delete_icon(resource) if include_delete %>
+  <%= yield if block_given? %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,46 +1,43 @@
 <div class="container">
-  <div class="section">
+  <section class="section">
     <div class="columns">
       <div class="column">
         <h1 class="title"><%= @event.name %></h1>
         <p class="subtitle"><%= date_range(@event) %></p>
-        <div class="content">
+
+        <% if @event_attendee %>
+          <div class="block">
+            <%= render "components/message", css_class: "is-info" do %>
+              You are <%= link_to @event_attendee.organizer? ? "organizing" : "attending", event_attendee_path(@event_attendee) %> this event.
+            <% end %>
+          </div>
+        <% end %>
+
+        <div class="content block">
           <%= kramdown(@event.description) %>
         </div>
 
+        <div class="block">
+          <%= qr_code(event_url(@event)) %>
+        </div>
+
+        <div class="block">
+          <%= buttons(@event, include_nav: true, include_delete: false) %>
+        </div>
       </div>
 
       <div class="column is-one-quarter">
-        <div class="mb-3">
-          <% if current_user&.profile&.attending? @event %>
-            <%= button_to "Cancel Attendance",
-            { controller: :event_attendees,
-            action: :destroy,
-            id: current_user&.profile&.event_attendee(@event)&.first&.id },
-            method: :delete,
-            class: "button is-danger" %>
-          <% elsif current_user %>
-            <%= button_to "Attend",
-              event_attendees_path(
-                event_attendee: {
-                                  profile_id: current_user.profile&.id,
-                                  event_id: @event.id
-                              }
-            ),
-            action: "create",
-            class: "button is-primary" %>
+        <div class="block">
+          <% if @event_attendee %>
+            <%= delete_button @event_attendee, title: "Cancel Attendance" %>
+          <% elsif current_user&.profile %>
+            <%= attend_event_button event: @event, profile: current_user.profile %>
           <% end %>
         </div>
-        <%= render "event_attendees/list", event_attendees: @event_attendees %>
+        <div class="block">
+          <%= render "event_attendees/list", event_attendees: @event_attendees %>
+        </div>
       </div>
     </div>
-  </div>
-
-  <section class="section">
-    <%= qr_code(event_url(@event)) %>
   </section>
-
-  <div class="section">
-    <%= buttons(@event, include_nav: true, include_delete: false) %>
-  </div>
 </div>

--- a/app/views/layouts/_alerts.html.erb
+++ b/app/views/layouts/_alerts.html.erb
@@ -1,7 +1,5 @@
 <% if notice || alert %>
-<article class="message is-hidden-tablet <%= alert_color %>">
-  <div class="message-body">
+  <%= render "components/notification", css_class: "is-hidden-tablet #{alert_color}" do %>
     <%= notice || alert %>
-  </div>
-</article>
+  <% end %>
 <% end %>

--- a/app/views/layouts/_errors.html.erb
+++ b/app/views/layouts/_errors.html.erb
@@ -1,14 +1,9 @@
 <% if resource.errors.any? %>
-  <article class="message is-danger">
-    <div class="message-header">
-      <%= "#{pluralize(resource.errors.count, "error")} prohibited this #{resource.to_s} from being saved:" %>
-    </div>
-    <div class="message-body">
-      <ul>
-        <% resource.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  </article>
+  <%= render "components/message", css_class: "is-danger", message_header: error_header(resource) do %>
+    <ul>
+      <% resource.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  <% end %>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -2,14 +2,8 @@
   <h1 class="title">Notifications</h1>
 
   <% @notifications.each do |notification| %>
-    <div class="message">
-      <div class="message-header">
-        <p><%= l(notification.created_at, format: :long) %></p>
-        <%= button_to("", notification, method: :delete, class: "delete") %>
-      </div>
-      <div class="message-body">
+    <%= render "components/notification", css_class:"is-info", resource: notification, include_delete: true do %>
       <%= link_to notification.message, notification.url %>
-      </div>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -9,11 +9,9 @@
             <%= image_tag profile_picture(@current_user.email), alt: "Profile pic" %>
           </figure>
         <div class="media-content">
-          <article class="message is-info">
-            <div class="message-body">
-              Our avatars are sourced from <a href="https://gravatar.com">Gravatar!</a> If you need <a href="#avatar-help">more help, see below.</a>
-            </div>
-          </article>
+          <%= render "components/message", css_class: "is-info" do %>
+            Our avatars are sourced from <a href="https://gravatar.com">Gravatar!</a> If you need <a href="#avatar-help">more help, see below.</a>
+          <% end %>
         </div>
       </div>
     </div>
@@ -29,51 +27,42 @@
   <% end %>
 </div>
 
-<div class="block">
-  <article id="avatar-help" class="message is-info">
-    <div class="message-header">Avatar Help</div>
-    <div class="message-body">
-      <p class="mb-3">
-        Your avatar is sourced from <a href="https://gravatar.com">Gravatar</a> - a free service that provides avatars based on your email address.
-        If you don't have an avatar set, a default image will be used.
-      </p>
-      <p class="mb-3">
-        To change your avatar, create or update your Gravatar account with the email address associated with your profile.
-        Once updated, your new avatar will appear here!
-      </p>
-      <p class="mb-3">
-        Gravatar is used by many sites, including Slack, WordPress, and GitHub, so your avatar will be consistent across those platforms as well.
-      </p>
-      <%= link_to "Back to Form", "#top" %>
-    </div>
-  </article>
+<div id="avatar-help" class="block">
+  <%= render "components/message", message_header: "Avatar Help", css_class: "is-info" do %>
+    <p class="mb-3">
+      Your avatar is sourced from <a href="https://gravatar.com">Gravatar</a> - a free service that provides avatars based on your email address.
+      If you don't have an avatar set, a default image will be used.
+    </p>
+    <p class="mb-3">
+      To change your avatar, create or update your Gravatar account with the email address associated with your profile.
+      Once updated, your new avatar will appear here!
+    </p>
+    <p class="mb-3">
+      Gravatar is used by many sites, including Slack, WordPress, and GitHub, so your avatar will be consistent across those platforms as well.
+    </p>
+    <%= link_to "Back to Form", "#top" %>
+  <% end %>
 </div>
 
-<div class="block">
-  <article id="bio-help" class="message is-info">
-    <div class="message-header">Bio Advice</div>
-    <div class="message-body">
-      <p class="mb-3">
-        Your bio is a brief introduction to yourself that is only visible to people who can see your profile and events.
-        It could include major professional accomplishments, conversation starters, and information about how to contact and refer to you.
-        We recommed including pronouns, links to social media profiles or email, and how you'd like to meet others at the event.
-        Check your friend's or public profiles for inspiration!
-      </p>
-      <%= link_to "Back to Form", "#top" %>
-    </div>
-  </article>
+<div id="bio-help" class="block">
+  <%= render "components/message", message_header: "Bio Advice", css_class: "is-info" do %>
+    <p class="mb-3">
+      Your bio is a brief introduction to yourself that is only visible to people who can see your profile and events.
+      It could include major professional accomplishments, conversation starters, and information about how to contact and refer to you.
+      We recommed including pronouns, links to social media profiles or email, and how you'd like to meet others at the event.
+      Check your friend's or public profiles for inspiration!
+    </p>
+    <%= link_to "Back to Form", "#top" %>
+  <% end %>
 </div>
 
-<div class="block">
-  <article id="visibilities-help" class="message is-info">
-    <div class="message-header">Profile Visibilities</div>
-    <div class="message-body">
-      <p class="mb-3">Location data, where you've been and where you're going, is sensitive information! We take that responsibility seriously. These permissions impact who can read your bio, and see which events you are attending. There are multiple layers of authorization for you to pick from.</p>
-      <p class="mb-2"><strong>everyone</strong> - Anyone can view your events. Authenticated, unauthenticated, robots, anyone! If you want to grab your events with an API call or embed them with an iFrame, this is the permission for you!</p>
-      <p class="mb-2"><strong>authenticated</strong> - Users of the site who have confirmed their email address can see which events you are attending. Recommended for those who have an audience, but still want some protections around their events.</p>
-      <p class="mb-2"><strong>friends</strong> - Only profiles that you have friended can see which events you will attend. This is the default. If someone friends you, they will not see your events until you friend them.</p>
-      <p class="mb-3"><strong>myself</strong> - You are the only one who can see which events you are attending. Admins can still view your events for moderation purposes. Intended for bad situations where you need to hide info in a hurry, and people who'd just like to use the app as a diary for events they've attended.</p>
-      <%= link_to "Back to Form", "#top" %>
-    </div>
-  </article>
+<div id="visibilities-help" class="block">
+  <%= render "components/message", message_header: "Profile Visibilities", css_class: "is-info" do %>
+    <p class="mb-3">Location data, where you've been and where you're going, is sensitive information! We take that responsibility seriously. These permissions impact who can read your bio, and see which events you are attending. There are multiple layers of authorization for you to pick from.</p>
+    <p class="mb-2"><strong>everyone</strong> - Anyone can view your events. Authenticated, unauthenticated, robots, anyone! If you want to grab your events with an API call or embed them with an iFrame, this is the permission for you!</p>
+    <p class="mb-2"><strong>authenticated</strong> - Users of the site who have confirmed their email address can see which events you are attending. Recommended for those who have an audience, but still want some protections around their events.</p>
+    <p class="mb-2"><strong>friends</strong> - Only profiles that you have friended can see which events you will attend. This is the default. If someone friends you, they will not see your events until you friend them.</p>
+    <p class="mb-3"><strong>myself</strong> - You are the only one who can see which events you are attending. Admins can still view your events for moderation purposes. Intended for bad situations where you need to hide info in a hurry, and people who'd just like to use the app as a diary for events they've attended.</p>
+    <%= link_to "Back to Form", "#top" %>
+  <% end %>
 </div>


### PR DESCRIPTION
## Description of Feature or Issue
We use messages and notifications _all over the app_, it's one of our most used components. I've extracted them into 2 partials - notification and message - and replaced all the usages of it.

In addition, this PR adds a new message to the event page - telling the user if they are attending or organizing.
It also changes the style for mobile alerts and notices.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<img width="336" height="295" alt="New alert and old alert" src="https://github.com/user-attachments/assets/77705002-66bc-4e63-8227-9cef83f1ffbe" />
<img width="334" height="240" alt="New notice and old notice" src="https://github.com/user-attachments/assets/dc4bba6f-5579-44b6-8fab-aa92546eadc1" />
<img width="989" height="841" alt="You are organizing message" src="https://github.com/user-attachments/assets/83d8b027-22f0-4c25-823a-13db1aa0964d" />
**Please note that I am speaking at, but not organizing XO Ruby Atlanta, this is for demonstration purposes only.**
<img width="989" height="809" alt="You are attending message" src="https://github.com/user-attachments/assets/3225b363-8965-40a3-b652-b7e40b22ea41" />


