### PR TITLE
fix: improve handle error message and validation

### DIFF
--- a/app/models/concerns/handleable.rb
+++ b/app/models/concerns/handleable.rb
@@ -5,7 +5,7 @@
 module Handleable
   extend ActiveSupport::Concern
 
-  URL_POSSIBLE_REGEX = /\A[A-z0-9\-]+\z/
+  URL_POSSIBLE_REGEX = /\A[A-Za-z0-9\-_]+\z/
 
   included do
     validates :handle, presence: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,11 +8,11 @@ en:
         event:
           attributes:
             handle:
-              invalid: "only allows letters and numbers"
+              invalid: "only allows letters, numbers, underscores, and hyphens"
         profile:
           attributes:
             handle:
-              invalid: "only allows letters and numbers"
+              invalid: "only allows letters, numbers, underscores, and hyphens"
   event_attendees:
     list:
       buddies_attending:


### PR DESCRIPTION
## Description of Feature or Issue


<!-- Outline why changes/addition have been made -->
Improves the error message when a handle is not specified. Previously the error message stated that only letters and numbers were allowed, but the regex actually allowed more characters, including `-` (hyphen) and `_` (underscore). 

The regex also permitted a broader range of ASCII characters than expected. This updates the regex to only allow A-Z a-z _ and -. 

Previously the regex had `A-z` which also permitted the ASCII characters between `Z` and `a`, which includes `[`, `\`, ` and `]`. 



## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<!-- If there have been user facing change please include screenshots -->
