### PR TITLE
Devcontainer update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,11 @@
 	],
 
 	// git does not recognize the user in a devcontainer - https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/
-	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-
+	// "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+	"postStartCommand": "bundle exec rails s -b 0.0.0.0",
+	"mounts": [
+		"source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+	],
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "web",
@@ -23,7 +26,8 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/sshd:1": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
## Description of Feature or Issue
closes #323 

Automatically start Rails server on start of devcontainer.

## Summary of Changes

This pull request updates the `.devcontainer/devcontainer.json` configuration to improve the development experience in the dev container. The main changes focus on updating the post-start command, mounting SSH keys, and adding SSH support to the container.

**Dev container configuration improvements:**

* Changed the `postStartCommand` to start the Rails server on all interfaces instead of only configuring Git safe directory.
* Added a mount to bind the host's `.ssh` directory into the container to enable SSH key access.
* Added the `sshd` feature to the container, enabling SSH support for development workflows.

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
<!-- If there have been user facing change please include screenshots -->
